### PR TITLE
Add detailed DTC HTML report

### DIFF
--- a/DTCAnalyzerApp/Form1.Designer.cs
+++ b/DTCAnalyzerApp/Form1.Designer.cs
@@ -31,6 +31,7 @@ namespace DTCAnalyzerApp
         {
             button1 = new System.Windows.Forms.Button();
             button2 = new System.Windows.Forms.Button();
+            button3 = new System.Windows.Forms.Button();
             SuspendLayout();
             // 
             // button1
@@ -52,10 +53,21 @@ namespace DTCAnalyzerApp
             button2.Text = "ODB + UDS";
             button2.UseVisualStyleBackColor = true;
             button2.Click += button2_Click;
-            // 
+            //
+            // button3
+            //
+            button3.Location = new System.Drawing.Point(-2, 122);
+            button3.Name = "button3";
+            button3.Size = new System.Drawing.Size(272, 23);
+            button3.TabIndex = 2;
+            button3.Text = "Reporte Completo";
+            button3.UseVisualStyleBackColor = true;
+            button3.Click += button3_Click;
+            //
             // Form1
-            // 
-            ClientSize = new System.Drawing.Size(282, 166);
+            //
+            ClientSize = new System.Drawing.Size(282, 212);
+            Controls.Add(button3);
             Controls.Add(button2);
             Controls.Add(button1);
             Name = "Form1";
@@ -66,5 +78,6 @@ namespace DTCAnalyzerApp
 
         private System.Windows.Forms.Button button1;
         private System.Windows.Forms.Button button2;
+        private System.Windows.Forms.Button button3;
     }
 }

--- a/DTCAnalyzerApp/Form1.cs
+++ b/DTCAnalyzerApp/Form1.cs
@@ -43,5 +43,20 @@ namespace DTCAnalyzerApp
             }
             
         }
+
+        private void button3_Click(object sender, EventArgs e)
+        {
+            OpenFileDialog dialog = new OpenFileDialog();
+            dialog.Filter = "TRC files (*.trc)|*.trc";
+            if (dialog.ShowDialog() == DialogResult.OK)
+            {
+                string inputPath = dialog.FileName;
+                string htmlPath = DTCInterpreter.GenerarReporteCompleto(inputPath);
+                MessageBox.Show(@"Reporte generado:" +
+"" + htmlPath, "Éxito", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                System.Diagnostics.Process.Start("explorer", htmlPath);
+            }
+
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add `GenerarReporteCompleto` to build an extended DTC report
- expose new report through a third button in the WinForms UI
- wire up button handler and designer updates

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68863ac71a20833293ae5afd34e87e03